### PR TITLE
Use splice in `on` to avoid memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ export function picoapp (components = {}, initialState = {}) {
 
   function on (ev, fn) {
     events[ev] = (events[ev] || []).concat(fn)
-    return () => events[ev].slice(events[ev].indexOf(fn), 1)
+    return () => events[ev].splice(events[ev].indexOf(fn), 1)
   }
 
   const context = {


### PR DESCRIPTION
Hey Eric, I've been admiring your work for a while now and I'm really enjoying this clever little library!

While reading the source, I think I caught a typo in the `on` method where `slice` was used instead of `splice`, so here's a tiny PR.

 Cheers 🍻

