### PR TITLE
only unmount components that return a function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/README.md
+++ b/README.md
@@ -132,14 +132,10 @@ export default component((node, ctx) => {
 })
 ```
 
-And then, call `unmount()`. If the component no longer exists in the DOM, its
-`unmount` handler will be called.
+And then, call `unmount()`. All [evx](https://github.com/estrattonbailey/evx) event subscriptions within your component will be destroyed automatically.
 ```javascript
 app.unmount()
 ```
-
-Regardless of if you define an `unmount` handler, any event subscriptions you
-made in your component will be destroyed.
 
 `unmount()` is also synchronous, so given a PJAX library like
 [operator](https://github.com/estrattonbailey/operator), you can do this *after*
@@ -150,6 +146,8 @@ router.on('after', state => {
   app.mount() // init new components
 })
 ```
+
+If your component does not define an `unmount` handler, the component will remain mounted after calling `unmount` (including all [evx](https://github.com/estrattonbailey/evx) event subscriptions within the component). This is useful for components that persist across AJAX page transitions such as global navigation or even a WebGL canvas.
 
 ## Other Stuff
 The `picoapp` instance also has access to start and the event bus:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import { create } from 'evx'
 
 const isObj = v => typeof v === 'object' && !Array.isArray(v)
+const isFn = v => typeof v === 'function'
 
 // make sure evx and picoapp don't destroy the same events
 export function component (create) {
@@ -57,7 +58,8 @@ export function picoapp (components = {}, initialState = {}) {
               node.removeAttribute(attr) // so can't be bound twice
 
               try {
-                cache.push(comp(node, evx))
+                const instance = comp(node, evx)
+                isFn(instance.unmount) && cache.push(instance)
               } catch (e) {
                 console.log(`🚨 %cpicoapp - ${modules[m]} failed - ${e.message || e}`, 'color: #E85867')
                 console.error(e)
@@ -71,11 +73,9 @@ export function picoapp (components = {}, initialState = {}) {
       for (let i = cache.length - 1; i > -1; i--) {
         const { unmount, node, subs } = cache[i]
 
-        if (!document.documentElement.contains(node)) {
-          unmount && unmount(node)
-          subs.map(u => u())
-          cache.splice(i, 1)
-        }
+        unmount(node)
+        subs.map(u => u())
+        cache.splice(i, 1)
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3248,7 +3248,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3269,12 +3270,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3289,17 +3292,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3416,7 +3422,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3428,6 +3435,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3442,6 +3450,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3449,12 +3458,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3473,6 +3484,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3553,7 +3565,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3565,6 +3578,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3650,7 +3664,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3686,6 +3701,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3705,6 +3721,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3748,12 +3765,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Addresses #8

During `mount`, component instances are only cached if they return a function. Additionally, the `!document.documentElement.contains(node)` condition has been removed from `unmount`. So, if a component does not return a function, `evx` event subscriptions are preserved after calling `unmount`. If a component _does_ return a function, the function will be called and all `evx` event subscriptions will be destroyed — regardless of whether or not the component is still in the DOM.

Added a test for this new behavior and updated the readme.

Let me know what you think!