### PR TITLE
Unwrap dynamically imported modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,14 @@ export function picoapp (components = {}, initialState = {}) {
 
               try {
                 const instance = comp(node, evx)
-                isFn(instance.unmount) && cache.push(instance)
+                if (instance.then) {
+                  instance.then((value) => {
+                    const asyncInstance = value.default(node, evx);
+                    isFn(asyncInstance.unmount) && cache.push(asyncInstance);
+                  });
+                } else {
+                  isFn(instance.unmount) && cache.push(instance);
+                }
               } catch (e) {
                 console.log(`🚨 %cpicoapp - ${modules[m]} failed - ${e.message || e}`, 'color: #E85867')
                 console.error(e)


### PR DESCRIPTION
@estrattonbailey Hi Eric, sorry it took me a while to get to this, but played with a small change that I think is working pretty great to allow Webpack's dynamic imports.

This commit checks if the loaded instance is a promise, unwraps it if it is, and then instantiate the object as picoapp normally would. 

https://github.com/estrattonbailey/picoapp/issues/7

Thank you!