### PR TITLE
Extending the component API

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,5 +185,25 @@ app.mount([
 ])
 ```
 
+## Plugins
+
+The `picoapp` instance allows you to extend the component API through plugins. Plugins are functions that return objects, which then get merged into the `context` object passed to your `component`. Note that name conflicts with plugin properties will always be overriden by [picoapp's context](#state-&-events).
+
+To define plugins, pass a function to the `use` method. The example below adds a `props` object extracted from the component node's `data-props` attribute:
+```javascript
+app.use(node => {
+  const props = JSON.parse(node.dataset.props || '{}')
+  return {props}
+})
+```
+
+And then acccess plugin extensions from your component:
+```javascript
+const foo = component(node, ctx) => {
+  const { images = [] } = ctx.props
+  console.log(`start preloading ${images.length} images...`)
+})
+```
+
 ## License
 MIT License © [Eric Bailey](https://estrattonbailey.com)

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ export function picoapp (components = {}, initialState = {}, plugins = []) {
 
               try {
                 const ext = plugins.reduce((res, fn) => {
-                  const obj = fn(node)
+                  const obj = fn(node, evx)
                   return isObj(obj) ? Object.assign(res, obj) : res
                 }, {})
                 const instance = comp(node, {...ext, ...evx})

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const isFn = v => typeof v === 'function'
 
 // make sure evx and picoapp don't destroy the same events
 export function component (create) {
-  return function initialize (node, ctx, args = {}) {
+  return function initialize (node, ctx) {
     let subs = []
     return {
       subs,
@@ -16,7 +16,7 @@ export function component (create) {
           subs.push(u)
           return u
         }
-      }, args),
+      }),
       node
     }
   }
@@ -62,11 +62,11 @@ export function picoapp (components = {}, initialState = {}, plugins = []) {
               node.removeAttribute(attr) // so can't be bound twice
 
               try {
-                const args = plugins.reduce((res, fn) => {
+                const ext = plugins.reduce((res, fn) => {
                   const obj = fn(node)
                   return isObj(obj) ? Object.assign(res, obj) : res
                 }, {})
-                const instance = comp(node, evx, args)
+                const instance = comp(node, {...ext, ...evx})
                 isFn(instance.unmount) && cache.push(instance)
               } catch (e) {
                 console.log(`🚨 %cpicoapp - ${modules[m]} failed - ${e.message || e}`, 'color: #E85867')

--- a/test.js
+++ b/test.js
@@ -89,14 +89,12 @@ test('unmount', t => {
 test('plugins', t => {
 
   const app = picoapp({
-    foo: component((node, ctx, args) => {
-      t.true(args.props.hello === 'World')
-      t.true(typeof args.findOne === 'function')
+    foo: component((node, ctx) => {
+      t.true(ctx.props.hello === 'World')
     })
   })
 
-  app.use(node => ({
-    findOne: s => node.querySelector(s),
+  app.use((node, ctx) => ({
     props: JSON.parse(node.dataset.props || '{}')
   }))
 

--- a/test.js
+++ b/test.js
@@ -87,14 +87,23 @@ test('unmount', t => {
   app.emit('foo')
 })
 test('plugins', t => {
+  t.plan(2)
+
+  function testContext(ctx) {
+    const internals = ['getState', 'hydrate', 'on', 'emit']
+    const preserved = internals.every(key => typeof ctx[key] === 'function')
+    t.true(preserved)
+  }
 
   const app = picoapp({
     foo: component((node, ctx) => {
       t.true(ctx.props.hello === 'World')
+      testContext(ctx);
     })
   })
 
   app.use((node, ctx) => ({
+    getState: undefined,
     props: JSON.parse(node.dataset.props || '{}')
   }))
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,9 @@ import test from 'ava'
 import { picoapp, component } from './dist/picoapp.js'
 
 const createNode = attr => ({
+  dataset: {
+    props: '{"hello": "World"}'
+  },
   getAttribute () {
     return attr
   },
@@ -64,7 +67,7 @@ test('mount', t => {
 })
 test('unmount', t => {
   t.plan(4)
-  
+
   const app = picoapp({
     foo: component((node, ctx) => {
       ctx.on('foo', () => t.truthy(1))
@@ -76,10 +79,26 @@ test('unmount', t => {
   })
 
   app.mount()
-  
+
   app.emit('foo')
-  
+
   app.unmount()
-  
+
   app.emit('foo')
+})
+test('plugins', t => {
+
+  const app = picoapp({
+    foo: component((node, ctx, args) => {
+      t.true(args.props.hello === 'World')
+      t.true(typeof args.findOne === 'function')
+    })
+  })
+
+  app.use(node => ({
+    findOne: s => node.querySelector(s),
+    props: JSON.parse(node.dataset.props || '{}')
+  }))
+
+  app.mount()
 })


### PR DESCRIPTION
Hi @estrattonbailey - thanks for your work on picoapp - it has become a default dependency on all of my latest WordPress projects!

I've found myself re-using a few patterns with my components and thought it might be interesting to add plugin functionality to extend / enhance the component API. Perhaps easier to explain with some usage examples:

```js
const foo = component(node, ctx, {
  findOne, 
  props,
  refs
}) => {
  const submit = findOne('button[type="submit"]')
  const { name, email } = refs
  console.log(`start preloading ${props.images.length} images...`)
})

const app = picoapp({foo})

// adds findOne and findAll utility functions that query in context of the current node
app.use(node => ({
  findOne: s => node.querySelector(s),
  findAll: s => Array.from(node.querySelectorAll(s))
})

// pass WordPress / ACF fields to the component via data-props attribute
// data-props='<?php echo json_encode(['images' => $images]) ?>'
app.use(node => {
  const props = JSON.parse(node.dataset.props || '{}')
  return {props}
})

// pull out all child elements with a ref attribute 
// (inspired by https://github.com/terkelg/facon)
app.use(node => {
  const refs = Array.from(node.querySelectorAll('[ref]')).reduce((acc, child) => {
    const key = child.getAttribute('ref').trim()
    acc[key] = acc[key]
      ? Array.isArray(acc[key])
        ? [...acc[key], child]
        : [acc[key], child]
      : child;
    return acc
  }, {})
  return {refs}
})

app.mount()
```

I've added a new test case, but probably could be more thorough. I'm also passing the extensions / plugin api through as `args` - not crazy about that name, but I'd likely be destructuring this in my component definition anyway. Curious what you think - and no worries if it doesn't fit your vision of **picoapp** (or there are issues with this implementation that I'm not seeing 😬). 

Cheers!